### PR TITLE
Drop people with income == 0!

### DIFF
--- a/Calibration/SetupSCFdata.py
+++ b/Calibration/SetupSCFdata.py
@@ -49,6 +49,10 @@ scf_data_path = data_location = os.path.dirname(
 
 data = pd.read_csv(scf_data_path + "/SCFdata.csv")
 
+# Keep only observations with normal incomes > 0,
+# otherwise wealth/income is not well defined
+data = data[data.norminc > 0.0]
+
 # Initialize empty lists for the data
 w_to_y_data = []  # Ratio of wealth to permanent income
 empirical_weights = []  # Weighting for this observation


### PR DESCRIPTION
The current code uses SCF data to find (and then target in estimation) median wealth-to-income ratios. But, it does not drop people with income == 0, so some target moments are `nan` and the objective function is `nan` for every set of parameters... at least for me.

Does anyone else run into the same issue?

This PR fixes the issue.