### PR TITLE
fix(ci): resolve nox color conflict and exclude generated CSVs from pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
         with:
           extra_args: --hook-stage manual --all-files
       - name: Run PyLint
+        env:
+          # Avoid nox error: "Can not specify both --no-color and --force-color".
+          # GHA is non-TTY (nox uses --no-color); workflow sets FORCE_COLOR (-> --force-color).
+          FORCE_COLOR: ""
         run: pipx run nox -s pylint -- --output-format=github
 
   checks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,8 @@ ci:
   autoupdate_commit_msg: "chore: update pre-commit hooks"
   autofix_commit_msg: "style: pre-commit fixes"
 
-exclude: ^.cruft.json|.copier-answers.yml$
+# Exclude generated files: CSV tables under content/tables/ are generated
+exclude: ^.cruft.json|.copier-answers.yml$|.*/content/tables/.*
 
 repos:
   - repo: https://github.com/adamchainz/blacken-docs


### PR DESCRIPTION
## Summary
Fixes CI failures in the Format job.

## Changes
1. **Nox color conflict**: Unset `FORCE_COLOR` in the Run PyLint step so nox no longer sees both `--no-color` (from GHA non-TTY) and `--force-color` (from workflow env), which caused:
   ```
   nox: error: Can not specify both --no-color and --force-color.
   ```

2. **Pre-commit on generated files**: Exclude `content/tables/` from pre-commit globally. CSVs under `src/content/tables/` and `src/estimark/content/tables/` are generated; end-of-file-fixer, mixed-line-ending, and trailing-whitespace were failing on them.

## Testing
- Pushing this branch will trigger CI; Format job should pass with these changes.

Made with [Cursor](https://cursor.com)