### PR TITLE
Add AGENTS.md and fix LaTeX math rendering in paper

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1,0 +1,87 @@
+# Code Architecture
+
+## Package layout (`src/estimark/`)
+
+```
+src/estimark/
+├── __init__.py        # Exports __version__ (from hatch-vcs)
+├── estimation.py      # Core estimation loop and all estimation functions
+├── agents.py          # Life-cycle HARK consumer types (5 agent classes)
+├── parameters.py      # All calibration values, bounds, age mappings
+├── options.py         # Resource-level presets (low/medium/high/all)
+├── scf.py             # Loads SCF 2004 wealth-income data from CSV
+└── snp.py             # Loads S&P target-date glidepath from Excel
+```
+
+## Module dependency graph
+
+```
+do_all.py / run_all.py
+    └── estimation.estimate()
+            ├── agents.py        (make_agent)
+            ├── parameters.py    (calibration, bounds, mappings)
+            ├── scf.py           (empirical wealth data)
+            ├── snp.py           (portfolio share targets)
+            └── estimagic        (optimizer: em.minimize / em.estimate_msm)
+                └── HARK         (agent.solve(), agent.simulate())
+```
+
+## Key design patterns
+
+### Agent construction via multiple inheritance
+
+Each agent type combines two base classes:
+1. `TempConsumerType` — Custom `sim_birth` (draws from discrete initial wealth
+   distribution) and `sim_death` (no death during simulation).
+2. A HARK consumer type — Provides `solve()`, `simulate()`, consumption/portfolio
+   functions.
+
+```python
+class PortfolioLifeCycleConsumerType(TempConsumerType, PortfolioConsumerType):
+    ...
+```
+
+Python MRO means `TempConsumerType.sim_birth` overrides the HARK default.
+
+### Agent name string as feature flag
+
+The `agent.name` string (e.g. `"WarmGlowPortfolioSub(Stock)(Labor)Market"`)
+drives conditional logic throughout `estimation.py`:
+- `"Portfolio" in agent_name` → add share moments, track `Share` variable
+- `"WarmGlow" in agent_name` → compute `BeqFac`/`BeqShift` from `BeqMPC`/`BeqInt`
+- `"Sub" in agent_name` → use subjective belief calibrations
+- `"(Stock)" in agent_name` → subjective stock market beliefs
+- `"(Labor)" in agent_name` → subjective labor market beliefs
+
+### Estimation result persistence
+
+Results are saved as headerless two-column CSVs (`param_name, value`) in
+`content/tables/{min,msm,TRP}/`. On subsequent runs, `get_initial_guess()`
+reads these files to warm-start the optimizer.
+
+## Scripts outside the package
+
+| Script | Purpose |
+|--------|---------|
+| `src/do_all.py` | Interactive CLI: choose model, resource level, subjective beliefs |
+| `src/run_all.py` | Batch run of TRP models (Portfolio, WealthPortfolio, WarmGlowPortfolio) |
+| `src/run_all_msm.py` | MSM estimation for all agent types with Dask parallelism |
+| `src/tests.py` | Legacy test script (broken import: `from estimark.min`; should be `estimark.estimation`) |
+
+## Data files (`src/data/`)
+
+| File | Contents |
+|------|----------|
+| `SCFdata.csv` | 2004 Survey of Consumer Finances: age, wealth-income ratio, weights |
+| `S&P Target Date glidepath.xlsx` | S&P target-date fund equity share by age |
+| `Cagetti2003.csv` | Cagetti (2003) income process calibration data |
+
+## Content output (`content/`)
+
+Estimation runs produce:
+- `content/tables/min/` — Minimum-distance estimation CSVs
+- `content/tables/msm/` — Method-of-simulated-moments CSVs
+- `content/tables/TRP/` — Target Retirement Portfolio CSVs
+- `content/figures/` — Sensitivity bar charts, SMM contour plots (SVG/PNG/PDF)
+
+These are checked into version control as reproducibility artifacts.

--- a/.agents/build-and-ci.md
+++ b/.agents/build-and-ci.md
@@ -1,0 +1,119 @@
+# Build System and CI
+
+## Package build
+
+**Build backend**: Hatchling with hatch-vcs for version management.
+
+```toml
+[build-system]
+requires = ["hatchling", "hatch-vcs"]
+build-backend = "hatchling.build"
+```
+
+Version is derived from git tags and written to `src/estimark/_version.py`.
+Build with:
+```bash
+nox -s build    # or: python -m build
+```
+
+## Dependency management
+
+Core dependencies are intentionally empty in `[project.dependencies]` — all
+runtime deps are in optional groups:
+
+| Group | Deps | Install |
+|-------|------|---------|
+| `run` | numpy, pandas, matplotlib, scipy, statsmodels, estimagic, HARK | `pip install .[run]` |
+| `test` | pytest, pytest-cov | `pip install .[test]` |
+| `dev` | pytest, pytest-cov | `pip install .[dev]` |
+| `docs` | sphinx, myst_parser, furo, etc. | `pip install .[docs]` |
+
+HARK is installed from GitHub master: `HARK @ git+https://github.com/econ-ark/HARK@master`
+
+A conda environment file also exists: `environment.yml` (Python 3.12, includes
+Dask for parallel MSM estimation).
+
+## Nox sessions (`noxfile.py`)
+
+| Session | Command | Purpose |
+|---------|---------|---------|
+| `lint` | `nox -s lint` | Run pre-commit on all files |
+| `pylint` | `nox -s pylint` | Run PyLint on `estimark` |
+| `tests` | `nox -s tests` | Run pytest |
+| `docs` | `nox -s docs` | Build Sphinx docs (with autobuild in interactive mode) |
+| `build_api_docs` | `nox -s build_api_docs` | Generate API docs with sphinx-apidoc |
+| `build` | `nox -s build` | Build sdist + wheel |
+
+Default sessions: `lint`, `pylint`, `tests`.
+
+## Pre-commit hooks (`.pre-commit-config.yaml`)
+
+| Hook | Purpose |
+|------|---------|
+| blacken-docs | Format Python in docs |
+| pre-commit-hooks | Standard checks (large files, merge conflicts, trailing whitespace, etc.) |
+| pygrep-hooks | RST syntax checks |
+| prettier | Format YAML, Markdown, HTML, CSS, JS, JSON (with `--prose-wrap=always`) |
+| ruff | Python linting + formatting |
+| mypy | Type checking (on `src/` and `tests/`) |
+| codespell | Spell checking |
+| shellcheck | Shell script linting |
+| validate-pyproject | Validate pyproject.toml |
+| check-jsonschema | Validate dependabot, GitHub workflows, ReadTheDocs configs |
+
+**Important**: Pre-commit excludes `content/tables/` CSVs and `.copier-answers.yml`.
+
+## CI workflows (`.github/workflows/`)
+
+### `ci.yml` — Main CI
+
+Triggered on push to `main` and PRs.
+
+1. **Format job**: pre-commit + PyLint
+2. **Checks job**: pytest across matrix:
+   - Python: 3.8, 3.13, pypy-3.10
+   - OS: ubuntu-latest, windows-latest, macos-14
+   - Coverage uploaded to Codecov
+
+### `cd.yml` — Continuous Deployment
+
+Triggered on releases. Builds sdist/wheel and publishes to Test PyPI.
+
+### `deploy.yml` — Documentation Deployment
+
+Triggered on push to `main`. Builds MyST site and deploys to GitHub Pages.
+
+## Linting and formatting configuration
+
+All in `pyproject.toml`:
+
+```toml
+[tool.ruff]
+src = ["src"]
+# ...
+
+[tool.mypy]
+files = "src"
+python_version = "3.8"
+strict = true
+# Various overrides for untyped HARK imports
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+```
+
+## Template origin
+
+This repo was generated from the
+[scientific-python/cookie](https://github.com/scientific-python/cookie) template
+(see `.copier-answers.yml`). Many config files follow that template's conventions.
+
+## Known issues
+
+- `src/tests.py` has a broken import (`from estimark.min import estimate_min`);
+  the correct module is `estimark.estimation`. This file is not run by pytest
+  (which only looks in `tests/`).
+- `n_cores: 12` is hardcoded in `parameters.py` minimize_options — may need
+  adjustment for different machines.
+- The actual test suite (`tests/test_package.py`) only checks the package
+  version; there are no functional tests for the estimation pipeline.

--- a/.agents/economics-context.md
+++ b/.agents/economics-context.md
@@ -1,0 +1,121 @@
+# Economics Context
+
+This file provides domain knowledge needed to work with the models in this
+repository. Agents working on this codebase should understand these concepts to
+avoid introducing economically nonsensical changes.
+
+## The life-cycle consumption-saving problem
+
+A consumer lives from age 25 to (at most) 120, faces uncertain income, and must
+decide how much to consume vs. save each period. The consumer retires at age 65.
+The goal: maximize expected lifetime utility of consumption (and possibly
+bequests), discounted by a time preference factor.
+
+### Key economic parameters
+
+- **CRRA (rho)**: Coefficient of Relative Risk Aversion. Higher values mean the
+  consumer is more averse to consumption fluctuations. Typical estimated values
+  are 2–10. Must be > 1 for the model to behave well.
+- **DiscFac (beth)**: Discount factor adjustment. Multiplied by an age-varying
+  sequence. Values near 1.0 mean the consumer values future consumption almost
+  as much as current. Must be in (0.5, 1.1).
+- **Rfree**: Risk-free interest rate (gross, so 1.03 = 3% return).
+
+### Income process
+
+Uses Cagetti (2003) calibration for college-educated households:
+- Permanent income grows deterministically with age (hump-shaped)
+- Subject to permanent and transitory shocks (log-normal)
+- Unemployment risk: 5% probability with 30% replacement rate while working
+- Post-retirement: much smaller shocks, 0.5% "unemployment" probability
+
+### Wealth-to-income ratio
+
+The key moment matched in estimation. For each age group, compute the median
+ratio of financial wealth (`bNrm`, normalized by permanent income) across
+simulated agents, and compare to the SCF empirical median.
+
+## Model variants
+
+### IndShock (baseline)
+
+Standard buffer-stock saving model. Only parameters: CRRA (and possibly DiscFac).
+Consumer chooses consumption; remainder is saved at the risk-free rate.
+
+### Portfolio
+
+Adds choice between a risky asset (stocks) and risk-free asset (bonds) each
+period. Additional moments to match: equity portfolio share by age from S&P
+target-date fund glidepath data.
+
+The `post_solve` method sets `cFunc = cFuncAdj` (the consumption function
+conditional on adjusting the portfolio) because the model assumes costless
+portfolio rebalancing.
+
+### WarmGlow (bequest motive)
+
+Adds a "warm glow" bequest utility: the consumer gets utility from leaving
+wealth at death, parameterized by:
+- **BeqMPC**: Pseudo marginal propensity to consume from bequests. Internally
+  transformed: `BeqFac = BeqMPC^(-CRRA)`
+- **BeqInt**: Pseudo intercept. Internally transformed:
+  `BeqShift = BeqInt / BeqMPC`
+
+These reparameterizations ensure the optimizer searches over economically
+meaningful quantities rather than the raw structural parameters.
+
+### WarmGlowPortfolio
+
+Combines bequest motive and portfolio choice. Estimates CRRA, BeqMPC, BeqInt,
+and matches both wealth and portfolio share moments.
+
+### WealthPortfolio
+
+An alternative to bequests: utility is defined over both consumption AND wealth
+holdings directly (wealth in the utility function). Parameters:
+- **WealthShare**: Weight on wealth in utility (0 to 1)
+- **WealthShift**: Shift parameter for wealth utility
+
+## Subjective beliefs
+
+Optional extensions add subjective (potentially biased) beliefs about:
+- **Stock market**: Consumer may perceive different risk/return than reality.
+  Model is solved with subjective beliefs but simulated with true parameters.
+  Calibrated from Mateo Velasquez-Giraldo's JMP.
+- **Labor market**: Consumer may perceive different income risk. Calibrated from
+  Tao Wang's JMP.
+
+Activated via the agent name string: `"Sub(Stock)"`, `"Sub(Labor)"`, or
+`"Sub(Stock)(Labor)"`.
+
+## Data sources
+
+### SCF 2004 (`src/data/SCFdata.csv`)
+
+Survey of Consumer Finances, 2004 wave. Contains:
+- `wealth_income_ratio`: Financial wealth / permanent income
+- `age_group`: Age bracket labels matching `age_mapping`
+- `weight`: Survey sampling weights
+
+Weighted medians are computed using `statsmodels.DescrStatsW`.
+
+### S&P Target Date Glidepath (`src/data/S&P Target Date glidepath.xlsx`)
+
+Equity allocation percentages by age from S&P target-date index funds. Used as
+empirical portfolio share moments for Portfolio-type models.
+
+### Cagetti 2003
+
+Income process calibration (growth rates, shock variances by age). Accessed
+through HARK's `Calibration.Income.IncomeTools.Cagetti_income`.
+
+## Notation conventions
+
+The paper and code use Econ-ARK notation extensively. Key symbols defined as
+LaTeX macros in `myst.yml`:
+- `\CRRA` (rho) — relative risk aversion
+- `\DiscFac` (beta) — discount factor
+- `\Rfree` — risk-free gross return
+- `\PermGroFac` — permanent income growth factor
+- `\MPC` — marginal propensity to consume
+- `\wealth` — wealth level

--- a/.agents/estimation-pipeline.md
+++ b/.agents/estimation-pipeline.md
@@ -1,0 +1,107 @@
+# Estimation Pipeline
+
+## Overview
+
+The core loop: given parameter values, solve a life-cycle model, simulate many
+agents, compute age-group median wealth-to-income ratios, and compare against
+SCF data. The optimizer (estimagic) searches over parameters to minimize the
+distance.
+
+## Two estimation methods
+
+### 1. Minimum-distance (`estimate_method="min"`)
+
+Uses `em.minimize()` with a custom criterion function (`msm_criterion`) that
+returns a scalar loss plus root-contributions for least-squares optimizers.
+
+```
+em.minimize(msm_criterion, initial_params, criterion_kwargs={agent, emp_moments, weights})
+```
+
+Default optimizer: `tranquilo_ls` with multistart enabled.
+
+### 2. Method of Simulated Moments (`estimate_method="msm"`)
+
+Uses `em.estimate_msm()` which handles the weighting matrix construction
+internally from a moments covariance matrix.
+
+```
+em.estimate_msm(simulate_moments, emp_moments, moments_cov, initial_params)
+```
+
+## Step-by-step flow
+
+### `estimation.estimate()` — the main entry point
+
+1. **Create agent**: `make_agent(agent_name)` instantiates the appropriate HARK
+   type with calibrated parameters from `parameters.init_calibration`.
+
+2. **Get initial guess**: `get_initial_guess()` reads from a previous results
+   CSV if available, otherwise falls back to `init_params_options["init_guess"]`.
+
+3. **Get empirical moments**: `get_empirical_moments(agent_name)` computes
+   weighted medians of wealth-income ratio by age group from SCF data. For
+   Portfolio agents, also adds share moments from S&P glidepath data.
+
+4. **Compute weights**: `calculate_weights()` normalizes by max wealth stat.
+   Portfolio share moments get a separate weighting factor (currently set to 1.0).
+
+5. **Run optimizer**: `do_estimate_model()` calls either `estimate_min()` or
+   `estimate_msm()`. Results saved to CSV.
+
+6. **Optional post-estimation**:
+   - Bootstrap standard errors (`do_compute_se_boostrap`)
+   - Sensitivity analysis via Jacobian (`do_compute_sensitivity`)
+   - Contour plot of objective function (`do_make_contour_plot`)
+
+### `simulate_moments(params, agent, emp_moments)` — the inner loop
+
+Called many times by the optimizer. Each call:
+
+1. `agent.assign_parameters(**params)` — update CRRA, DiscFac, etc.
+2. Handle derived parameters (e.g. `BeqFac = BeqMPC^(-CRRA)`)
+3. Handle subjective beliefs if applicable (swap in subjective distributions
+   for solving, true distributions for simulating)
+4. `agent.update()` → `agent.solve()` → `agent.initialize_sim()` → `agent.simulate()`
+5. Extract `bNrm` (bank balances) history, compute median by age group
+6. For Portfolio agents, also extract `Share` history
+7. Return dict of simulated moments keyed by age-group labels
+
+### `msm_criterion(params, agent, emp_moments, weights)` — the loss function
+
+Computes weighted squared errors between simulated and empirical moments:
+```
+loss = sum( (weight_k * (sim_k - emp_k))^2  for k in moments )
+```
+
+Returns a dict with `value` (scalar loss), `contributions` (squared errors),
+and `root_contributions` (signed errors) for least-squares optimizers.
+
+## Age groups and mappings
+
+Defined in `parameters.py`:
+- **`age_mapping`**: Maps labels like `"(25,30]"` to arrays of real ages
+  `[26, 27, 28, 29, 30]`
+- **`sim_mapping`**: Same labels mapped to simulation time indices (age minus
+  `initial_age=25`)
+- Ages 61–70 are excluded from SCF matching (retirement transition)
+- S&P share data only used for ages 71+
+
+## Optimizer configuration (`parameters.minimize_options`)
+
+```python
+{
+    "algorithm": "tranquilo_ls",
+    "multistart": True,
+    "algo_options": {
+        "convergence.absolute_params_tolerance": 1e-6,
+        "convergence.absolute_criterion_tolerance": 1e-6,
+        "stopping.max_iterations": 100,
+        "stopping.max_criterion_evaluations": 200,
+        "n_cores": 12,
+    },
+}
+```
+
+The `n_cores: 12` setting is hardcoded — may need adjustment for different
+machines.

--- a/.agents/paper-and-docs.md
+++ b/.agents/paper-and-docs.md
@@ -1,0 +1,112 @@
+# Paper and Documentation System
+
+## Paper (`content/paper/`)
+
+The research paper "Structural Estimation of Life Cycle Models with Wealth in
+the Utility Function" is written in **MyST Markdown** and built with the
+[MyST](https://mystmd.org/) toolchain.
+
+### Key files
+
+| File | Purpose |
+|------|---------|
+| `content/paper/01-paper.md` | Main paper source (MyST Markdown with directives, cross-refs, citations) |
+| `content/paper/main.bib` | BibTeX bibliography |
+| `content/paper/math.ipynb` | Notebook with mathematical derivations |
+| `content/paper/images/` | Static images referenced in the paper |
+| `content/paper/structural_estimation_pdf_tex/` | LaTeX/PDF output from paper build |
+
+### Building the paper
+
+```bash
+myst build          # Build the MyST site (HTML)
+myst build --pdf    # Build PDF output
+```
+
+The GitHub Actions workflow `deploy.yml` builds and deploys to GitHub Pages on
+push to `main`.
+
+### MyST configuration (`myst.yml`)
+
+The `myst.yml` file at the repo root is ~800 lines, primarily because it
+contains an extensive set of LaTeX math macros shared across the paper. These
+macros follow Econ-ARK notation conventions:
+
+```yaml
+math:
+  \CRRA: \rho
+  \DiscFac: \beta
+  \Rfree: \mathsf{R}
+  # ... hundreds more
+```
+
+When editing the paper, use these macros rather than raw LaTeX symbols to
+maintain consistency with the broader Econ-ARK ecosystem.
+
+### Citation format
+
+Uses `sphinxcontrib-bibtex` style references:
+```markdown
+{cite}`carroll2004` or {cite:t}`carroll2004`
+```
+
+## Sphinx documentation (`docs/`)
+
+A separate Sphinx-based documentation site exists in `docs/`:
+- `docs/conf.py` — Sphinx config (myst_parser, autodoc, Furo theme)
+- `docs/index.md` — Landing page (includes README)
+- Built for ReadTheDocs (`/.readthedocs.yaml`)
+
+Build locally:
+```bash
+nox -s docs
+```
+
+## Slides (`content/slides/`)
+
+Presentation slides built with Quarto:
+- `slides.ipynb` — Source notebook
+- `slides.tex` — LaTeX output
+- `strucutral_estimation.html` — HTML output (note: typo in filename is
+  intentional/historical)
+
+## Generated content
+
+Estimation runs produce artifacts checked into version control:
+
+### Tables (`content/tables/`)
+
+- `min/` — Minimum-distance estimates (e.g. `IndShock_estimate_results.csv`)
+- `msm/` — Method-of-simulated-moments estimates
+- `TRP/` — Target Retirement Portfolio estimates
+
+Format: headerless two-column CSV (`parameter_name, value`), plus metadata rows
+like `time_to_estimate`.
+
+### Figures (`content/figures/`)
+
+SVG, PNG, and PDF figures:
+- `*Sensitivity.svg` — Sensitivity bar charts
+- `*SMMcontour.svg` — Contour plots of the objective function
+
+### Notebooks (`src/notebooks/`)
+
+Jupyter notebooks for individual model estimations and analysis:
+- `IndShock.ipynb`, `Portfolio.ipynb`, `WarmGlow.ipynb`, etc.
+- `Model_Comparisons.ipynb` — Cross-model comparison
+- `SCF_notebook.ipynb` — SCF data exploration
+- `parse_tables.ipynb` — Table formatting utilities
+
+### MSM notebooks (`src/msm_notebooks/`)
+
+Separate notebooks for method-of-simulated-moments estimation, including
+covariance computation notebooks (`NetWorth_Cov.ipynb`, `FinAssets_Cov.ipynb`).
+
+## Table of Contents (`_toc.yml`)
+
+Defines the MyST site structure:
+```yaml
+root: README
+chapters:
+  - file: content/paper/01-paper
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md — EstimatingMicroDSOPs (estimark)
+
+This repository implements structural estimation of life-cycle consumption-saving
+models using the [HARK](https://github.com/econ-ark/HARK) toolkit and
+[estimagic](https://estimagic.readthedocs.io/) optimizer. It matches simulated
+wealth-to-income ratio profiles against median holdings from the 2004 Survey of
+Consumer Finances (SCF), organized around five agent types of increasing
+complexity.
+
+See `.agents/` for detailed guides on specific subsystems.
+
+## Quick orientation
+
+| Path | Purpose |
+|------|---------|
+| `src/estimark/` | Installable Python package (estimation, agents, calibration) |
+| `src/do_all.py` | Interactive CLI entry point for running replications |
+| `src/notebooks/` | Jupyter notebooks for individual model estimations |
+| `content/paper/` | Research paper in MyST Markdown (`01-paper.md`) |
+| `content/tables/` | Generated CSV estimation results (min/, msm/, TRP/) |
+| `content/figures/` | Generated SVG/PNG/PDF figures |
+| `tests/` | pytest tests (minimal — just version check currently) |
+| `myst.yml` | MyST site config with extensive LaTeX math macros |
+| `noxfile.py` | Nox sessions: lint, pylint, tests, docs, build |
+
+## Key conventions
+
+- **Package name** is `estimark`; repo name is `EstimatingMicroDSOPs`.
+- **Build system**: Hatchling + hatch-vcs. Version derived from git tags,
+  written to `src/estimark/_version.py`.
+- **No core dependencies** are declared in `[project.dependencies]`. Runtime
+  deps live in `[project.optional-dependencies].run` (numpy, pandas, matplotlib,
+  scipy, statsmodels, estimagic, HARK from GitHub master).
+- **Code style**: ruff for linting/formatting, mypy for type checking, codespell
+  for spell checking. All enforced via pre-commit (`.pre-commit-config.yaml`).
+- **Pre-commit excludes** CSV files under `content/tables/` since they are
+  generated output.
+- **Python version support**: 3.8–3.13 (per pyproject.toml classifiers and CI
+  matrix).
+- Imports use `from __future__ import annotations` throughout.
+
+## Agent types (model hierarchy)
+
+1. **IndShock** — Standard income-shock life-cycle model (CRRA only)
+2. **Portfolio** — Adds portfolio choice between risky and risk-free assets
+3. **WarmGlow** — Adds warm-glow bequest motive (BeqMPC, BeqInt params)
+4. **WarmGlowPortfolio** — Bequest motive + portfolio choice
+5. **WealthPortfolio** — Wealth-in-utility + portfolio choice (WealthShare,
+   WealthShift params)
+
+Each agent class in `agents.py` inherits from a `TempConsumerType` mixin
+(custom `sim_birth`/`sim_death`) and the corresponding HARK consumer type via
+multiple inheritance.
+
+## Parameters estimated
+
+| Parameter | Description | Typical bounds |
+|-----------|-------------|----------------|
+| `CRRA` | Coefficient of relative risk aversion | [1.1, 20.0] |
+| `DiscFac` | Discount factor adjustment | [0.5, 1.1] |
+| `BeqMPC` | Bequest pseudo-MPC | [0.0, 1.0] |
+| `BeqInt` | Bequest pseudo-intercept | [0.0, 10.0] |
+| `WealthShare` | Wealth-in-utility share | [0.01, 0.99] |
+| `WealthShift` | Wealth-in-utility shift | [0.0, 100.0] |
+
+## Running estimations
+
+```bash
+# Interactive
+python src/do_all.py
+
+# Direct (example: WarmGlowPortfolio with min-distance)
+python src/estimark/estimation.py
+
+# Batch TRP models
+python src/run_all.py
+
+# Batch MSM with Dask parallelism
+python src/run_all_msm.py
+```
+
+## Common tasks for agents
+
+- **Adding a new agent type**: Subclass `TempConsumerType` + the HARK type in
+  `agents.py`, add to `agent_types` dict in `estimation.py`, update
+  `params_to_estimate` in `options.py` if new parameters are introduced.
+- **Changing calibration**: Edit `parameters.py`. Key dicts are
+  `init_calibration`, `init_params_options`, `age_mapping`, `sim_mapping`.
+- **Modifying the paper**: Edit `content/paper/01-paper.md` (MyST Markdown).
+  Math macros are defined in `myst.yml`. Build with `myst build`.
+- **Running CI locally**: `nox -s lint`, `nox -s tests`, or
+  `pre-commit run --all-files`.
+
+## Files agents should not modify without care
+
+- `content/tables/` — Generated output; regenerate by running estimations
+- `src/data/` — Empirical data files (SCF, S&P glidepath, Cagetti)
+- `myst.yml` math macros — Shared notation; changes affect entire paper
+- `.copier-answers.yml` — Template metadata from scientific-python/cookie

--- a/content/paper/01-paper.md
+++ b/content/paper/01-paper.md
@@ -168,9 +168,9 @@ mortality, and income risk.
 The agent's objective is to maximize present discounted utility from consumption
 over the life cycle with a terminal period of $T$:
 
-\begin{equation} \vFunc*{t}(\pLvl*{t},\mLvl*{t}) = \max*{\{\cFunc\}_{t}^{T}} ~
-\uFunc(\cLvl_{t})+\Ex*{t}\left[\sum*{n=1}^{T-t} {\beth}^{n}
-\Alive*{t}^{t+n}\hat{\DiscFac}*{t}^{t+n} \uFunc(\cLvl\_{t+n}) \right]
+\begin{equation} \vFunc_{t}(\pLvl_{t},\mLvl_{t}) = \max_{\{\cFunc\}_{t}^{T}} ~
+\uFunc(\cLvl_{t})+\Ex_{t}\left[\sum_{n=1}^{T-t} {\beth}^{n}
+\Alive_{t}^{t+n}\hat{\DiscFac}_{t}^{t+n} \uFunc(\cLvl_{t+n}) \right]
 \label{eq:lifecyclemax} \end{equation}
 
 where $\pLvl_{t}$ is the permanent income level, $\mLvl_{t}$ is total market
@@ -187,31 +187,31 @@ problem of permanent income and wealth into a 1 dimensional problem of wealth
 normalized by permanent income. The recursive Bellman equation can be expressed
 as:
 
-\begin{align} {\vFunc}_{t}({m}_{t}) & = \max*{\cNrm*{t}} ~
-\uFunc(\cNrm*{t})+\beth\Alive*{t+1}\hat{\DiscFac}_{t+1}
+\begin{align} {\vFunc}_{t}({m}_{t}) & = \max_{\cNrm_{t}} ~
+\uFunc(\cNrm_{t})+\beth\Alive_{t+1}\hat{\DiscFac}_{t+1}
 \Ex_{t}[(\PermShk_{t+1}\PermGroFac_{t+1})^{1-\CRRA}{\vFunc}_{t+1}({m}_{t+1})] \\
-& \text{s.t.} & \\ \aNrm*{t} & = {m}*{t}-\cNrm*{t} \\ {m}*{t+1} & =
-\aNrm*{t}\underbrace{\left(\frac{\Rfree}{\PermShk*{t+1}\PermGroFac*{t+1}}\right)}*{\equiv
-\RNrm*{t+1}} + ~\TranShkEmp*{t+1} \end{align}
+& \text{s.t.} & \\ \aNrm_{t} & = {m}_{t}-\cNrm_{t} \\ {m}_{t+1} & =
+\aNrm_{t}\underbrace{\left(\frac{\Rfree}{\PermShk_{t+1}\PermGroFac_{t+1}}\right)}_{\equiv
+\RNrm_{t+1}} + ~\TranShkEmp_{t+1} \end{align}
 
 where $\cNrm$, $\aNrm$, and $\mNrm$ are consumption, assets, and market
 resources normalized by permanent income, respectively, $\vFunc$ and $\uFunc$
 are now the normalized value and utility functions, and
 
-\begin{align} \PermShk*{t+1} & : \text{mean-one shock to permanent income} \\
-\PermGroFac*{t+1} & : \text{permanent income growth factor} \\ \TranShkEmp*{t+1}
-& : \text{transitory shock to permanent income} \\ \RNrm*{t+1} & :
+\begin{align} \PermShk_{t+1} & : \text{mean-one shock to permanent income} \\
+\PermGroFac_{t+1} & : \text{permanent income growth factor} \\ \TranShkEmp_{t+1}
+& : \text{transitory shock to permanent income} \\ \RNrm_{t+1} & :
 \text{permanent income growth normalized return factor} \end{align}
 
 with all other variables are defined as above. The transitory and permanent
 shocks to income are defined as:
 
-\begin{align} \TranShkEmp*{s} = & \begin{cases} 0\phantom{/\pZero} & \text{with
-probability $\pZero>0$} \\ \xi*{s}/\pZero & \text{with probability $(1-\pZero)$,
+\begin{align} \TranShkEmp_{s} = & \begin{cases} 0\phantom{/\pZero} & \text{with
+probability $\pZero>0$} \\ \xi_{s}/\pZero & \text{with probability $(1-\pZero)$,
 where
 $\log \xi_{s}\thicksim \mathcal{N}(-\sigma_{[\xi, t]}^{2}/2,\sigma_{[\xi, t]}^{2})$}
-\end{cases} \\ \phantom{/\pZero} \\ & \text{and } \log \PermShk*{s} \thicksim
-\mathcal{N}(-\sigma*{[\PermShk, t]}^{2}/2,\sigma\_{[\PermShk, t]}^{2}).
+\end{cases} \\ \phantom{/\pZero} \\ & \text{and } \log \PermShk_{s} \thicksim
+\mathcal{N}(-\sigma_{[\PermShk, t]}^{2}/2,\sigma_{[\PermShk, t]}^{2}).
 \end{align}
 
 ## Wealth in the Utility Function
@@ -226,19 +226,19 @@ calling it the `Capitalist Spirit' model. In turn, we can add this feature to
 the LCIM model by adding a utility function with consumption and wealth. We call
 this the Wealth in the Utility Function Incomplete Markets (WUFIM) model.
 
-\begin{align} {\vFunc}_{t}({m}_{t}) & = \max*{\cNrm*{t}} ~ \uFunc(\cNrm*{t},
-\aNrm*{t})+\beth\Alive*{t+1}\hat{\DiscFac}*{t+1}
-\Ex*{t}[(\PermShk*{t+1}\PermGroFac*{t+1})^{1-\CRRA}{\vFunc}*{t+1}({m}_{t+1})] \\
+\begin{align} {\vFunc}_{t}({m}_{t}) & = \max_{\cNrm_{t}} ~ \uFunc(\cNrm_{t},
+\aNrm_{t})+\beth\Alive_{t+1}\hat{\DiscFac}_{t+1}
+\Ex_{t}[(\PermShk_{t+1}\PermGroFac_{t+1})^{1-\CRRA}{\vFunc}_{t+1}({m}_{t+1})] \\
 & \text{s.t.} & \\ \aNrm_{t} & = {m}_{t}-\cNrm_{t} \\ {m}_{t+1} & =
-\aNrm_{t}\RNrm*{t+1}+ ~\TranShkEmp*{t+1} \end{align}
+\aNrm_{t}\RNrm_{t+1}+ ~\TranShkEmp_{t+1} \end{align}
 
 **Separable Utility** [](doi:10.3386/w6549) presents extensive empirical and
 informal evidence for a LCIM model with wealth in the utility function.
 Specifically, the paper uses a utility that is separable in consumption and
 wealth:
 
-\begin{equation} \uFunc(\cNrm*{t}, \aNrm*{t}) =
-\frac{\cNrm*{t}^{1-\CRRA}}{1-\CRRA} + \kapShare*{t} \frac{(\aFunc\_{t} -
+\begin{equation} \uFunc(\cNrm_{t}, \aNrm_{t}) =
+\frac{\cNrm_{t}^{1-\CRRA}}{1-\CRRA} + \kapShare_{t} \frac{(\aFunc_{t} -
 \underline\aNrm)^{1-\wealthShare}}{1-\wealthShare} \end{equation}
 
 where $\kapShare$ is the relative weight of the utility of wealth and
@@ -251,8 +251,8 @@ this dynamic complementarity drives the accumulation of wealth not only for the
 sake of wealth itself, but also because it increases the marginal utility of
 consumption.
 
-\begin{equation} \uFunc(\cNrm*{t}, \aNrm*{t}) =
-\frac{(\cNrm*{t}^{1-\wealthShare} (\aNrm*{t} -
+\begin{equation} \uFunc(\cNrm_{t}, \aNrm_{t}) =
+\frac{(\cNrm_{t}^{1-\wealthShare} (\aNrm_{t} -
 \underline\aNrm)^\wealthShare)^{1-\CRRA}}{(1-\CRRA)} \end{equation}
 
 # Solution Methods
@@ -260,16 +260,16 @@ consumption.
 For a brief departure, let's consider how we solve these problems generally.
 Define the post-decision value function as:
 
-\begin{align} \DiscFac*{t+1} \wFunc*{t}(\aNrm*{t}) & =
-\beth\Alive*{t+1}\hat{\DiscFac}_{t+1}
+\begin{align} \DiscFac_{t+1} \wFunc_{t}(\aNrm_{t}) & =
+\beth\Alive_{t+1}\hat{\DiscFac}_{t+1}
 \Ex_{t}[(\PermShk_{t+1}\PermGroFac_{t+1})^{1-\CRRA}{\vFunc}_{t+1}({m}_{t+1})] \\
-& \text{s.t.} \\ {m}_{t+1} & = \aNrm_{t}\RNrm*{t+1}+ ~\TranShkEmp*{t+1}
+& \text{s.t.} \\ {m}_{t+1} & = \aNrm_{t}\RNrm_{t+1}+ ~\TranShkEmp_{t+1}
 \end{align}
 
 For our purposes, it will be useful to simplify the notation a bit by dropping
 time subscripts. The recursive problem can then be written as:
 
-\begin{align} \vFunc(\mRat) & = \max\_{\cNrm} ~ \uFunc(\cNrm, \aNrm) + \DiscFac
+\begin{align} \vFunc(\mRat) & = \max_{\cNrm} ~ \uFunc(\cNrm, \aNrm) + \DiscFac
 \wFunc(\aRat) \\ & \text{s.t.} \\ \aNrm & = \mRat-\cNrm \end{align}
 
 ## Endogenous Grid Method, Abridged
@@ -292,8 +292,8 @@ complicated and may not be invertible in terms of optimal consumption. Consider
 the first order condition for an optimal combination of consumption and savings,
 denoted by $^*$:
 
-\begin{equation} \uFunc*{c}'(\cNrm^*, \aNrm^_) - \uFunc_{a}'(\cNrm^_, \aNrm^_) =
-\DiscFac \wFunc'(\aNrm^\*) \end{equation}
+\begin{equation} \uFunc_{c}'(\cNrm^*, \aNrm^*) - \uFunc_{a}'(\cNrm^*, \aNrm^*) =
+\DiscFac \wFunc'(\aNrm^*) \end{equation}
 
 If the utility of consumption and wealth is additively separable, then the Euler
 equation can be written as
@@ -317,8 +317,8 @@ turns out to be more efficient than grid search maximization.
 Holding $\mNrm$ constant, we can define a function $f_{m}$ as the difference
 between the marginal utility of consumption and the marginal utility of wealth:
 
-\begin{equation} f*{m}(\cNrm) = \uFunc*{c}'(\cNrm, \mNrm - \cNrm) -
-\uFunc\_{a}'(\cNrm, \mNrm - \cNrm) - \DiscFac \wFunc'(\mNrm - \cNrm)
+\begin{equation} f_{m}(\cNrm) = \uFunc_{c}'(\cNrm, \mNrm - \cNrm) -
+\uFunc_{a}'(\cNrm, \mNrm - \cNrm) - \DiscFac \wFunc'(\mNrm - \cNrm)
 \end{equation}
 
 The optimal consumption policy is the value of $\cNrm$ that satisfies
@@ -412,7 +412,7 @@ consumption and savings over the life cycle. We can then calculate the simulated
 moments of the wealth distribution at the 7 age groups. We can define the
 objective function as
 
-\begin{equation} g(\Theta) = \sum*{\tau=1}^{7} \weight*{\tau} |\varsigma^{\tau}
+\begin{equation} g(\Theta) = \sum_{\tau=1}^{7} \weight_{\tau} |\varsigma^{\tau}
 -\mathbf{s}^{\tau}(\Theta)| \label{eq:naivePowell} \end{equation}
 
 where $\varsigma^{\tau}$ is the empirical moment of the wealth distribution at


### PR DESCRIPTION
## Summary

- **Add `AGENTS.md` and `.agents/` directory** with project context for AI coding agents, covering code architecture, estimation pipeline, economics domain knowledge, paper/docs system, and build/CI details.
- **Fix LaTeX subscript rendering** in `content/paper/01-paper.md`: throughout the math blocks, `*` had been used where `_` (subscript operator) should be, and `\_` (escaped underscore) where plain `_` was needed. This caused `myst start` to render literal asterisks instead of proper subscripts (e.g. `*c * t` instead of $c_t$). Fixed all 12 affected equation blocks.

## Details

### AGENTS.md / .agents/

New files providing structured context for AI agents working on this codebase:

| File | Purpose |
|------|---------|
| `AGENTS.md` | Top-level overview: project orientation, conventions, model hierarchy, common tasks |
| `.agents/architecture.md` | Package layout, module dependency graph, design patterns |
| `.agents/estimation-pipeline.md` | Step-by-step estimation flow, optimizer config, age mappings |
| `.agents/economics-context.md` | Domain knowledge: life-cycle models, parameters, data sources |
| `.agents/paper-and-docs.md` | MyST paper system, math macros, Sphinx docs, generated content |
| `.agents/build-and-ci.md` | Hatchling build, nox sessions, pre-commit, CI/CD workflows |

### Math rendering fixes

Three types of errors were fixed across 12 equation blocks in `01-paper.md`:

1. **`*{` → `_{`** — e.g. `\vFunc*{t}` → `\vFunc_{t}`, `\max*{\cNrm*{t}}` → `\max_{\cNrm_{t}}`
2. **`\_` → `_`** — e.g. `\max\_{\cNrm}` → `\max_{\cNrm}`, `\aFunc\_{t}` → `\aFunc_{t}`
3. **`^_` → `^*`** — In the FOC equation, optimal-value superscripts were mangled (`\cNrm^_` → `\cNrm^*`)

## Test plan

- [ ] Run `myst start` and verify all equations in the paper render with correct subscripts
- [ ] Verify the `AGENTS.md` and `.agents/` files are accessible and accurate

Made with [Cursor](https://cursor.com)